### PR TITLE
Add maven publish tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,10 +11,14 @@ plugins {
     id 'java-library'
     id 'com.github.johnrengelman.shadow' version '6.0.0'
     id 'idea'
+    id 'maven-publish'
 }
 
 sourceCompatibility = 11
 targetCompatibility = 11
+
+group = 'com.github.lulf.kafka-static-quota-plugin'
+version = '0.1'
 
 repositories {
     // Use jcenter for resolving dependencies.
@@ -38,3 +42,33 @@ test {
     // Use junit platform for unit tests
     useJUnitPlatform()
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+
+            from components.java
+
+            pom {
+                name = 'Kafka static quota plugin'
+                description = 'A broker quota plugin for Apache Kafka to allow setting a per-broker limits statically in the broker configuration.'
+                url = 'https://github.com/lulf/kafka-static-quota-plugin'
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'lulf'
+                        name = 'Ulf Lilleengen'
+                        email = 'ulilleen@redhat.com'
+                    }
+                }
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
This PR adds a maven publish task to the `build.gradle` file so the artifacts can be pushed to a local maven repo etc.